### PR TITLE
namespace 支持 lazy load

### DIFF
--- a/outplan/client.py
+++ b/outplan/client.py
@@ -69,9 +69,6 @@ class ExperimentGroupClient(object):
     def get_tracking_group(self, namespace_name, unit, user_id=None, pdid=None, track=True, **params):
         # type: (str, str, int, str, bool, Dict[Any, Any]) -> Any
         """取分组的全局唯一标识符，带上实验链的信息"""
-        if namespace_name not in self.namespaces:
-            raise ExperimentValidateError("Namespace {} not found.".format(namespace_name))
-
         namespace_item = self.get_namespace_item(namespace_name)
         tracking_group = namespace_item.get_group(unit, user_id=user_id, pdid=pdid, **params)
         if not track or not any([user_id, pdid]) or not self.tracking_client:

--- a/outplan/const.py
+++ b/outplan/const.py
@@ -5,3 +5,7 @@ class GroupResultType(object):
     """Type of group item result"""
     group = 1   # return result directly
     layer = 2   # namespace nested
+
+
+ONE_MINUTE = 60
+ONE_HOUR = ONE_MINUTE * 60

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with io.open(path.join(here, 'README.md'), encoding='utf-8') as f:
 setup(
     name='outplan',
 
-    version='1.1.1',
+    version='1.2.0',
 
     description='Support nested experiment/namespace base on Facebook Planout',
     long_description=long_description,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -263,11 +263,11 @@ def test_lazy_load_namespace():
         return NamespaceItem.from_dict(namespace_spec_dict)
 
     c = ExperimentGroupClient([], lazy_load_namespaces=['namespace_2'], lazy_load_func=lazy_load_it)
-    group = c.get_tracking_group('namespace_1', unit="12345", user_id=1, track=False)
+    group = c.get_tracking_group('namespace_2', unit="12345", user_id=1, track=False)
     assert (group.experiment_trace(), group.group_trace()) == ('homepage_exp.clt_p9', 'collect.c9-a0')
 
     with pytest.raises(ExperimentValidateError):
-        group = c.get_tracking_group('namespace_2', unit="12345", user_id=1, track=False)
+        group = c.get_tracking_group('namespace_4', unit="12345", user_id=1, track=False)
 
 
 def test_experiment_context():

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -264,7 +264,7 @@ def test_lazy_load_namespace():
 
     c = ExperimentGroupClient([], lazy_load_namespaces=['namespace_2'], lazy_load_func=lazy_load_it)
     group = c.get_tracking_group('namespace_2', unit="12345", user_id=1, track=False)
-    assert (group.experiment_trace(), group.group_trace()) == ('homepage_exp.clt_p9', 'collect.c9-a0')
+    assert (group.experiment_trace(), group.group_trace()) == ('homepage_exp_2.clt_p9_2', 'collect_2.c9-a1-2')
 
     with pytest.raises(ExperimentValidateError):
         group = c.get_tracking_group('namespace_4', unit="12345", user_id=1, track=False)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 
+import pytest
+
 from outplan.client import ExperimentGroupClient
+from outplan.exceptions import ExperimentValidateError
 from outplan.experiment import ExperimentItem, GroupItem, NamespaceItem
 from outplan.local import experiment_context
 
@@ -253,6 +256,18 @@ def test_experiment_group_client():
     # 三层嵌套
     assert (group.experiment_trace(), group.group_trace()) == ('homepage_ctl_2', 'h_ctl_2')
     assert group.group_extra_params == "hahaha"
+
+
+def test_lazy_load_namespace():
+    def lazy_load_it(namespace):
+        return NamespaceItem.from_dict(namespace_spec_dict)
+
+    c = ExperimentGroupClient([], lazy_load_namespaces=['namespace_2'], lazy_load_func=lazy_load_it)
+    group = c.get_tracking_group('namespace_1', unit="12345", user_id=1, track=False)
+    assert (group.experiment_trace(), group.group_trace()) == ('homepage_exp.clt_p9', 'collect.c9-a0')
+
+    with pytest.raises(ExperimentValidateError):
+        group = c.get_tracking_group('namespace_2', unit="12345", user_id=1, track=False)
 
 
 def test_experiment_context():

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -73,7 +73,7 @@ def test_get_greenlet_ident():
         def run(self):
             ids.append(greenlet_ident())
 
-    N_THREADS = 10
+    N_THREADS = 5
     threads = []
     for _ in range(N_THREADS):
         _thread = T()


### PR DESCRIPTION
现在的加载方式为在初始化 client 时，直接从 redis 读全部放进 client 里，这样的缺点是：
- 不能较为平滑的在线修改实验配置，修改完配置需要重启实例才会重新初始化 client，并从 redis 读
- 一次性把所有没用的的实验配置也读进来了

因此做了一些改动，从 redis 加载进来的实验配置只有在取分组的时候才 load 一次，并且设置一个 expire，过期之后再重新 load。
