### PR TITLE
嵌套namespace 因为预筛选找不到实验及分组时，返回 None

### DIFF
--- a/outplan/experiment.py
+++ b/outplan/experiment.py
@@ -338,10 +338,10 @@ class GroupItem(object):
                 _group = namespace.get_group(unit, **params)
                 if _group:
                     return _group
+            # 找不到合适的实验及分组
+            return None
         else:
             raise NotImplementedError()
-
-        raise ExperimentGroupNotFindError("未找到分组")
 
     def get_group_by_name(self, group_name):
         # type: (str) -> Optional[GroupItem]


### PR DESCRIPTION
与通过 bucket 切分流量找不到实验保持相同逻辑